### PR TITLE
chore: update OpenVidu/actions to v1.0.19

### DIFF
--- a/.github/workflows/browser-emulator.yml
+++ b/.github/workflows/browser-emulator.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
+        uses: OpenVidu/actions/install-safe-chain@58e9bb7b49e14849ee3cde9b532c4af48fe1d827 # v1.0.19
 
       - name: Install Vagrant & VirtualBox
         run: |


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.19`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.