### PR TITLE
chore: update OpenVidu/actions to v1.0.21

### DIFF
--- a/.github/workflows/browser-emulator.yml
+++ b/.github/workflows/browser-emulator.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/install-safe-chain@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
 
       - name: Install Vagrant & VirtualBox
         run: |


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.21`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.