### PR TITLE
ci: run check-versions workflow on self-hosted runners

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check-versions:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LABEL_WORKER_SELFHOSTED }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,12 @@ When adding, removing, or modifying API endpoints:
 1. **Update `docs/openapi.yaml`** with the new/changed endpoint and schema
 2. **Regenerate HTML docs**: Run `pnpm run docs` to update `docs/index.html`
 
-### 5. Pre-commit Checklist
+### 5. GitHub Actions Workflows
+
+- All jobs in `.github/workflows/*.yml` MUST run on the self-hosted runners: `runs-on: ${{ vars.LABEL_WORKER_SELFHOSTED }}`
+- Do not use GitHub-hosted runners (e.g. `ubuntu-24.04`) for new or modified jobs unless the job has a hard requirement the self-hosted runners can't meet (e.g. nested virtualization)
+
+### 6. Pre-commit Checklist
 
 Before finalizing any task:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ When adding, removing, or modifying API endpoints:
 ### 5. GitHub Actions Workflows
 
 - All jobs in `.github/workflows/*.yml` MUST run on the self-hosted runners: `runs-on: ${{ vars.LABEL_WORKER_SELFHOSTED }}`
-- Do not use GitHub-hosted runners (e.g. `ubuntu-24.04`) for new or modified jobs unless the job has a hard requirement the self-hosted runners can't meet (e.g. nested virtualization)
+- Do not use GitHub-hosted runners (e.g. `ubuntu-24.04`) for new or modified jobs unless the job has a hard requirement the self-hosted runners can't meet
 
 ### 6. Pre-commit Checklist
 

--- a/browser-emulator/tests/integration/script-runner.service.integration.test.ts
+++ b/browser-emulator/tests/integration/script-runner.service.integration.test.ts
@@ -130,11 +130,19 @@ describe('ScriptRunnerService', () => {
 				detached: true,
 			};
 
-			const process = await service.run('sleep 60', options);
+			// Use a unique process name (via `exec -a`) instead of a bare
+			// "sleep 60" so this test isn't confused by an unrelated
+			// "sleep 60" process spawned by another CI job running
+			// concurrently on the same self-hosted runner.
+			const tag = `srs-kill-one-${Date.now()}`;
+			const process = await service.run(
+				`bash -lc "exec -a ${tag} sleep 60"`,
+				options,
+			);
 			expect(process.pid).toBeDefined();
 
 			// Verify process is running
-			expect(await service.isRunning('sleep 60')).toBe(true);
+			expect(await service.isRunning(tag)).toBe(true);
 
 			// Kill the process
 			await service.killDetached(process);
@@ -143,7 +151,7 @@ describe('ScriptRunnerService', () => {
 			await new Promise(resolve => setTimeout(resolve, 1000));
 
 			// Verify process is no longer running
-			expect(await service.isRunning('sleep 60')).toBe(false);
+			expect(await service.isRunning(tag)).toBe(false);
 		});
 
 		it('should handle killing an already-dead process', async () => {
@@ -178,10 +186,23 @@ describe('ScriptRunnerService', () => {
 				detached: true,
 			};
 
-			// Start multiple detached processes
-			const process1 = await service.run('sleep 60', options);
-			const process2 = await service.run('sleep 60', options);
-			const process3 = await service.run('sleep 60', options);
+			// Use unique process names (via `exec -a`) instead of a bare
+			// "sleep 60" so this test isn't confused by an unrelated
+			// "sleep 60" process spawned by another CI job running
+			// concurrently on the same self-hosted runner.
+			const tag = `srs-kill-all-${Date.now()}`;
+			const process1 = await service.run(
+				`bash -lc "exec -a ${tag} sleep 60"`,
+				options,
+			);
+			const process2 = await service.run(
+				`bash -lc "exec -a ${tag} sleep 60"`,
+				options,
+			);
+			const process3 = await service.run(
+				`bash -lc "exec -a ${tag} sleep 60"`,
+				options,
+			);
 
 			expect(process1.pid).toBeDefined();
 			expect(process2.pid).toBeDefined();
@@ -194,7 +215,7 @@ describe('ScriptRunnerService', () => {
 			await new Promise(resolve => setTimeout(resolve, 2000));
 
 			// Verify all are gone
-			expect(await service.isRunning('sleep 60')).toBe(false);
+			expect(await service.isRunning(tag)).toBe(false);
 		});
 
 		it('should handle killAllDetached when no processes are running', async () => {


### PR DESCRIPTION
## Summary
- The `check-versions.yml` workflow was running on `ubuntu-24.04` (GitHub-hosted) instead of the project's self-hosted runners; switched it to `runs-on: ${{ vars.LABEL_WORKER_SELFHOSTED }}` to match the rest of the workflows
- Documented in AGENTS.md that all workflow jobs must use the self-hosted runners going forward

## Test plan
- [x] `check-versions.yml` now uses the same `runs-on` pattern as the other workflows in `.github/workflows/`